### PR TITLE
Fix types

### DIFF
--- a/src/events/Common/types.ts
+++ b/src/events/Common/types.ts
@@ -75,6 +75,13 @@ export type Item = {
     quantity: number
 }
 
-export type PaymentType = 'Pix à vista' | 'Pix parcelado' | 'Cartão de crédito' | 'Boleto' | 'Google Pay'
+export type PaymentType =
+    'Pix à vista'
+    | 'Pix parcelado'
+    | 'Cartão de crédito'
+    | 'Boleto'
+    | 'Google Pay'
+    | 'Gift card'
+    | ''
 
 export type CouponTypeName = 'Cupom' | 'Código de vendedor'

--- a/src/events/Purchase/types.ts
+++ b/src/events/Purchase/types.ts
@@ -7,7 +7,7 @@ export type PurchaseProps = {
     sale_coupon_name?: string
     coupon_name?: string
     total_discount: number
-    subtotal: 0
+    subtotal: number
     shipping: number
     currency: CurrencyName
     value: number


### PR DESCRIPTION
This pull request includes changes to the `src/events/Common/types.ts` and `src/events/Purchase/types.ts` files to enhance the flexibility of payment types and correct the type definition for `subtotal`.

Enhancements to payment types:

* [`src/events/Common/types.ts`](diffhunk://#diff-bf962f006a09d506f03d3a933ef3b86077983a9b1ed3f6a3385a1f47ea959c15L78-R85): Added 'Gift card' and an empty string as valid values to the `PaymentType` type.

Type definition correction:

* [`src/events/Purchase/types.ts`](diffhunk://#diff-4fe80793fc1a31a8a193bbb746059a808850127cdcaeadbd64e7b96dee6f4b50L10-R10): Changed the type of `subtotal` from a fixed value of `0` to `number` to correctly represent various subtotal values.